### PR TITLE
Merge pull request #358 from lucianomartin/feature/fix_empty_pipeline

### DIFF
--- a/satellite-xmos-firmware/audio_pipelines/reference/CMakeLists.txt
+++ b/satellite-xmos-firmware/audio_pipelines/reference/CMakeLists.txt
@@ -108,7 +108,8 @@ target_link_libraries(adec_altarch_aec_ic_ns_agc_2mic_2ref
 add_library(empty_2mic_2ref INTERFACE)
 target_sources(empty_2mic_2ref
     INTERFACE
-        ${CMAKE_CURRENT_LIST_DIR}/empty/audio_pipeline.c
+        ${CMAKE_CURRENT_LIST_DIR}/empty/audio_pipeline_t0.c
+        ${CMAKE_CURRENT_LIST_DIR}/empty/audio_pipeline_t1.c
 )
 target_include_directories(empty_2mic_2ref
     INTERFACE

--- a/satellite-xmos-firmware/audio_pipelines/reference/empty/audio_pipeline_dsp.h
+++ b/satellite-xmos-firmware/audio_pipelines/reference/empty/audio_pipeline_dsp.h
@@ -1,0 +1,20 @@
+/ Copyright 2024 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+#ifndef AUDIO_PIPELINE_DSP_H_
+#define AUDIO_PIPELINE_DSP_H_
+
+#include <stdint.h>
+#include "app_conf.h"
+
+
+/* Note: Changing the order here will effect the channel order for
+ * audio_pipeline_input() and audio_pipeline_output()
+ */
+typedef struct {
+    int32_t samples[appconfAUDIO_PIPELINE_CHANNELS][appconfAUDIO_PIPELINE_FRAME_ADVANCE];
+    int32_t aec_reference_audio_samples[appconfAUDIO_PIPELINE_CHANNELS][appconfAUDIO_PIPELINE_FRAME_ADVANCE];
+    int32_t mic_samples_passthrough[appconfAUDIO_PIPELINE_CHANNELS][appconfAUDIO_PIPELINE_FRAME_ADVANCE];
+} frame_data_t;
+
+#endif /* AUDIO_PIPELINE_DSP_H_ */

--- a/satellite-xmos-firmware/audio_pipelines/reference/empty/audio_pipeline_t0.c
+++ b/satellite-xmos-firmware/audio_pipelines/reference/empty/audio_pipeline_t0.c
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 XMOS LIMITED.
+// Copyright 2022-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 /* STD headers */
@@ -19,16 +19,13 @@
 /* App headers */
 #include "app_conf.h"
 #include "audio_pipeline.h"
+#include "audio_pipeline_dsp.h"
 
 #if appconfAUDIO_PIPELINE_FRAME_ADVANCE != 240
 #error This pipeline is only configured for 240 frame advance
 #endif
 
-typedef struct {
-    int32_t samples[appconfAUDIO_PIPELINE_CHANNELS][appconfAUDIO_PIPELINE_FRAME_ADVANCE];
-    int32_t aec_reference_audio_samples[appconfAUDIO_PIPELINE_CHANNELS][appconfAUDIO_PIPELINE_FRAME_ADVANCE];
-    int32_t mic_samples_passthrough[appconfAUDIO_PIPELINE_CHANNELS][appconfAUDIO_PIPELINE_FRAME_ADVANCE];
-} frame_data_t;
+#if ON_TILE(0)
 
 static void *audio_pipeline_input_i(void *input_app_data)
 {
@@ -99,3 +96,5 @@ void audio_pipeline_init(
                         appconfAUDIO_PIPELINE_TASK_PRIORITY,
                         stage_count);
 }
+
+#endif /* ON_TILE(0)*/

--- a/satellite-xmos-firmware/audio_pipelines/reference/empty/audio_pipeline_t1.c
+++ b/satellite-xmos-firmware/audio_pipelines/reference/empty/audio_pipeline_t1.c
@@ -1,0 +1,95 @@
+// Copyright 2024 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+/* STD headers */
+#include <string.h>
+#include <stdint.h>
+#include <xcore/hwtimer.h>
+
+/* FreeRTOS headers */
+#include "FreeRTOS.h"
+#include "task.h"
+#include "timers.h"
+#include "queue.h"
+#include "stream_buffer.h"
+
+/* Library headers */
+#include "generic_pipeline.h"
+
+/* App headers */
+#include "app_conf.h"
+#include "audio_pipeline.h"
+#include "audio_pipeline_dsp.h"
+
+#if appconfAUDIO_PIPELINE_FRAME_ADVANCE != 240
+#error This pipeline is only configured for 240 frame advance
+#endif
+
+#if ON_TILE(1)
+
+static void *audio_pipeline_input_i(void *input_app_data)
+{
+    frame_data_t *frame_data;
+    frame_data = pvPortMalloc(sizeof(frame_data_t));
+    memset(frame_data, 0x00, sizeof(frame_data_t));
+
+    audio_pipeline_input(input_app_data,
+                       (int32_t **)frame_data->aec_reference_audio_samples,
+                       4,
+                       appconfAUDIO_PIPELINE_FRAME_ADVANCE);
+
+    memcpy(frame_data->samples, frame_data->mic_samples_passthrough, sizeof(frame_data->samples));
+
+    return frame_data;
+}
+
+static int audio_pipeline_output_i(frame_data_t *frame_data,
+                                   void *output_app_data)
+{
+
+    rtos_intertile_tx(intertile_ctx,
+                      appconfAUDIOPIPELINE_PORT,
+                      frame_data,
+                      sizeof(frame_data_t));
+
+    return AUDIO_PIPELINE_FREE_FRAME;
+}
+
+void empty_stage(void)
+{
+    ;
+}
+
+static void initialize_pipeline_stages(void)
+{
+    ;
+}
+
+void audio_pipeline_init(
+    void *input_app_data,
+    void *output_app_data)
+{
+    const int stage_count = 2;
+    const pipeline_stage_t stages[] = {
+        (pipeline_stage_t)empty_stage,
+        (pipeline_stage_t)empty_stage,
+    };
+
+    const configSTACK_DEPTH_TYPE stage_stack_sizes[] = {
+        configMINIMAL_STACK_SIZE + RTOS_THREAD_STACK_SIZE(empty_stage) + RTOS_THREAD_STACK_SIZE(audio_pipeline_input_i),
+        configMINIMAL_STACK_SIZE + RTOS_THREAD_STACK_SIZE(empty_stage) + RTOS_THREAD_STACK_SIZE(audio_pipeline_output_i),
+    };
+
+    initialize_pipeline_stages();
+
+    generic_pipeline_init((pipeline_input_t)audio_pipeline_input_i,
+                        (pipeline_output_t)audio_pipeline_output_i,
+                        input_app_data,
+                        output_app_data,
+                        stages,
+                        (const size_t*) stage_stack_sizes,
+                        appconfAUDIO_PIPELINE_TASK_PRIORITY,
+                        stage_count);
+
+}
+#endif /* ON_TILE(1)*/


### PR DESCRIPTION
Merged from: https://github.com/xmos/sln_voice/pull/358

The audio_pipeline.c file in the empty pipeline has been split into a _t0 and a _t1 file. The content of the input and output functions have been updated so that they match the same behaviour in the other pipelines.

