### PR TITLE
adds adec and usb_adec build variants

### DIFF
--- a/satellite-xmos-firmware/dev_usb_record.cmake
+++ b/satellite-xmos-firmware/dev_usb_record.cmake
@@ -1,0 +1,138 @@
+query_tools_version()
+
+set(FFVA_AP adec)
+set(VARIANT_NAME dev_satellite1_usb_pipeline_analysis)
+
+set(FFVA_INT_COMPILE_DEFINITIONS
+${APP_COMPILE_DEFINITIONS}
+    appconfEXTERNAL_MCLK=0
+    appconfI2S_ENABLED=1
+    appconfUSB_ENABLED=1
+    appconfAEC_REF_DEFAULT=appconfAEC_REF_I2S
+    appconfI2S_MODE=appconfI2S_MODE_MASTER
+    appconfI2S_AUDIO_SAMPLE_RATE=16000
+    appconfI2S_ESP_ENABLED=1
+
+    ## VK Voice uses 12288000 for RPI integration, EXPLORER Board uses default 24576000
+    # MIC_ARRAY_CONFIG_MCLK_FREQ=12288000
+)
+
+message(${FFVA_INT_COMPILE_DEFINITIONS})
+
+#**********************
+# Tile Targets
+#**********************
+set(TARGET_NAME tile0_${VARIANT_NAME})
+add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL)
+target_sources(${TARGET_NAME} PUBLIC ${APP_SOURCES})
+target_include_directories(${TARGET_NAME} PUBLIC ${APP_INCLUDES})
+target_compile_definitions(${TARGET_NAME}
+    PUBLIC
+        ${FFVA_INT_COMPILE_DEFINITIONS}
+        THIS_XCORE_TILE=0
+)
+target_compile_options(${TARGET_NAME} PRIVATE ${APP_COMPILER_FLAGS})
+target_link_libraries(${TARGET_NAME}
+    PUBLIC
+        ${APP_COMMON_LINK_LIBRARIES}
+        sln_voice::app::ffva::xcore_ai_explorer
+        sln_voice::app::ffva::ap::${PL_NAME}
+        sln_voice::app::ffva::sp::passthrough
+)
+target_link_options(${TARGET_NAME} PRIVATE ${APP_LINK_OPTIONS})
+unset(TARGET_NAME)
+
+set(TARGET_NAME tile1_${VARIANT_NAME})
+add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL)
+target_sources(${TARGET_NAME} PUBLIC ${APP_SOURCES})
+target_include_directories(${TARGET_NAME} PUBLIC ${APP_INCLUDES})
+target_compile_definitions(${TARGET_NAME}
+    PUBLIC
+        ${FFVA_INT_COMPILE_DEFINITIONS}
+        THIS_XCORE_TILE=1
+)
+target_compile_options(${TARGET_NAME} PRIVATE ${APP_COMPILER_FLAGS})
+target_link_libraries(${TARGET_NAME}
+    PUBLIC
+        ${APP_COMMON_LINK_LIBRARIES}
+        sln_voice::app::ffva::xcore_ai_explorer
+        sln_voice::app::ffva::ap::${PL_NAME}
+        sln_voice::app::ffva::sp::passthrough
+)
+target_link_options(${TARGET_NAME} PRIVATE ${APP_LINK_OPTIONS})
+unset(TARGET_NAME)
+
+#**********************
+# Merge binaries
+#**********************    
+merge_binaries(${VARIANT_NAME} tile0_${VARIANT_NAME} tile1_${VARIANT_NAME} 1)
+
+#**********************
+# Create run and debug targets
+#**********************
+create_run_target(${VARIANT_NAME})
+create_debug_target(${VARIANT_NAME})
+create_upgrade_img_target(${VARIANT_NAME} ${XTC_VERSION_MAJOR} ${XTC_VERSION_MINOR})
+
+#**********************
+# Create data partition support targets
+#**********************
+set(TARGET_NAME ${VARIANT_NAME})
+set(DATA_PARTITION_FILE ${TARGET_NAME}_data_partition.bin)
+set(FATFS_FILE ${TARGET_NAME}_fat.fs)
+set(FATFS_CONTENTS_DIR ${TARGET_NAME}_fatmktmp)
+
+add_custom_target(
+    ${FATFS_FILE} ALL
+    COMMAND ${CMAKE_COMMAND} -E rm -rf ${FATFS_CONTENTS_DIR}/fs/
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${FATFS_CONTENTS_DIR}/fs/
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_LIST_DIR}/filesystem_support/demo.txt ${FATFS_CONTENTS_DIR}/fs/
+    COMMAND fatfs_mkimage --input=${FATFS_CONTENTS_DIR} --output=${FATFS_FILE}
+    COMMENT
+        "Create filesystem"
+    VERBATIM
+)
+
+set_target_properties(${FATFS_FILE} PROPERTIES
+    ADDITIONAL_CLEAN_FILES ${FATFS_CONTENTS_DIR}
+)
+
+# The filesystem is the only component in the data partition, copy it to
+# the assocated data partition file which is required for CI.
+add_custom_command(
+    OUTPUT ${DATA_PARTITION_FILE}
+    COMMAND ${CMAKE_COMMAND} -E copy ${FATFS_FILE} ${DATA_PARTITION_FILE}
+    DEPENDS
+        ${FATFS_FILE}
+    COMMENT
+        "Create data partition"
+    VERBATIM
+)
+
+list(APPEND DATA_PARTITION_FILE_LIST
+    ${FATFS_FILE}
+    ${DATA_PARTITION_FILE}
+)
+
+create_data_partition_directory(
+    #[[ Target ]]                   ${TARGET_NAME}
+    #[[ Copy Files ]]               "${DATA_PARTITION_FILE_LIST}"
+    #[[ Dependencies ]]             "${DATA_PARTITION_FILE_LIST}"
+)
+    
+create_flash_image_target(
+    #[[ Target ]]                  ${TARGET_NAME}
+    #[[ Boot Partition Size ]]     0x100000
+#   #[[ Data Partition Contents ]] ${DATA_PARTITION_FILE}
+#   #[[ Dependencies ]]            ${DATA_PARTITION_FILE}
+
+)
+create_flash_app_target(
+    #[[ Target ]]                  ${TARGET_NAME}
+    #[[ Boot Partition Size ]]     0x100000
+    #[[ Data Partition Contents ]] ${DATA_PARTITION_FILE}
+    #[[ Dependencies ]]            ${DATA_PARTITION_FILE}
+)
+
+unset(DATA_PARTITION_FILE_LIST)
+

--- a/satellite-xmos-firmware/explorer_devboard.cmake
+++ b/satellite-xmos-firmware/explorer_devboard.cmake
@@ -1,4 +1,7 @@
 query_tools_version()
+
+foreach(FFVA_AP ${FFVA_PIPELINES_INT})
+
 set(FFVA_INT_COMPILE_DEFINITIONS
 ${APP_COMPILE_DEFINITIONS}
     appconfEXTERNAL_MCLK=0
@@ -8,12 +11,11 @@ ${APP_COMPILE_DEFINITIONS}
     appconfI2S_MODE=appconfI2S_MODE_MASTER
     appconfI2S_AUDIO_SAMPLE_RATE=16000
     appconfI2S_ESP_ENABLED=1
-    #appconfPIPELINE_BYPASS=1
+
     ## VK Voice uses 12288000 for RPI integration, EXPLORER Board uses default 24576000
     # MIC_ARRAY_CONFIG_MCLK_FREQ=12288000
 )
 
-foreach(FFVA_AP ${FFVA_PIPELINES_INT})
     if(${FFVA_AP} STREQUAL bypass )
       set(PL_NAME fixed_delay)
       list(APPEND FFVA_INT_COMPILE_DEFINITIONS appconfPIPELINE_BYPASS=1)

--- a/satellite-xmos-firmware/firmware.cmake
+++ b/satellite-xmos-firmware/firmware.cmake
@@ -76,7 +76,7 @@ if(ENABLE_ALL_FFVA_PIPELINES)
     )
 else()
     set(FFVA_PIPELINES_INT
-        #fixed_delay
+        adec
         bypass
     )
 
@@ -89,3 +89,4 @@ endif()
 # XMOS Firmware Targets
 #**********************
 include(${CMAKE_CURRENT_LIST_DIR}/explorer_devboard.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/dev_usb_record.cmake)

--- a/tools/ci/firmwares.txt
+++ b/tools/ci/firmwares.txt
@@ -1,1 +1,2 @@
 satellite1_bypass  satellite1_firmware_bypass No  XCORE_AI_EXPLORER   xmos_cmake_toolchain/xs3a.cmake
+satellite1_adec  satellite1_firmware_adec No  XCORE_AI_EXPLORER   xmos_cmake_toolchain/xs3a.cmake


### PR DESCRIPTION
Adding **satellite1_firmware_adec** to list of targets to build locally.

Adding **dev_satellite1_usb_pipeline_analysis** target.
Uses the ADEC pipeline and additionally enables USB support.