### PR TITLE
Cleanup speaker pipeline macros

### DIFF
--- a/satellite-xmos-firmware/bsp_config/XCORE-AI-EXPLORER/platform/driver_instances.h
+++ b/satellite-xmos-firmware/bsp_config/XCORE-AI-EXPLORER/platform/driver_instances.h
@@ -21,6 +21,7 @@
 #define SPI_OUTPUT_TILE_NO 1
 #define MICARRAY_TILE_NO   1
 #define I2S_TILE_NO        1
+#define SPEAKER_PIPELINE_TILE_NO I2S_TILE_NO 
 
 /** TILE 0 Clock Blocks */
 #define FLASH_CLKBLK  XS1_CLKBLK_1

--- a/satellite-xmos-firmware/bsp_config/XCORE-AI-EXPLORER/platform/platform_conf.h
+++ b/satellite-xmos-firmware/bsp_config/XCORE-AI-EXPLORER/platform/platform_conf.h
@@ -51,6 +51,43 @@
 #define appconfI2S_RPC_PRIORITY (configMAX_PRIORITIES-2)
 #endif /* appconfI2S_RPC_PRIORITY */
 
+#ifndef appconfSPI_DEV_CTRL_PORT
+#define appconfSPI_DEV_CTRL_PORT 15
+#endif /* appconfSPI_DEV_CTRL_PORT */
+
+#ifndef appconfSPI_DEV_CTRL_PRIORITY
+#define appconfSPI_DEV_CTRL_PRIORITY (configMAX_PRIORITIES/2)
+#endif /* appconfSPI_DEV_CTRL_PRIORITY */
+
+
+/*****************************************/
+/*  I/O and interrupt cores for Tile 0   */
+/*****************************************/
+#ifndef appconfSPI_IO_CORE
+#define appconfSPI_IO_CORE                      1 /* Must be kept off core 0 with the RTOS tick ISR */
+#endif /* appconfSPI_IO_CORE */
+
+#ifndef appconfSPI_INTERRUPT_CORE
+#define appconfSPI_INTERRUPT_CORE               2 /* Must be kept off I/O cores. */
+#endif /* appconfSPI_INTERRUPT_CORE */
+
+#ifndef appconfI2C_IO_CORE
+#define appconfI2C_IO_CORE                      5 /* Must be kept off core 0 with the RTOS tick ISR */
+#endif /* appconfI2C_IO_CORE */
+
+#ifndef appconfI2C_INTERRUPT_CORE
+#define appconfI2C_INTERRUPT_CORE               4 /* Must be kept off I/O cores. */
+#endif /* appconfI2C_INTERRUPT_CORE */
+
+#ifndef appconfI2C_SEC_IO_CORE
+#define appconfI2C_SEC_IO_CORE                  6 /* Must be kept off core 0 with the RTOS tick ISR */
+#endif /* appconfI2C_SEC_IO_CORE */
+
+#ifndef appconfI2C_SEC_INTERRUPT_CORE
+#define appconfI2C_SEC_INTERRUPT_CORE           7 /* Must be kept off I/O cores. */
+#endif /* appconfI2C_INTERRUPT_CORE */
+
+
 /*****************************************/
 /*  I/O and interrupt cores for Tile 1   */
 /*****************************************/
@@ -70,25 +107,31 @@
 #define appconfI2S_INTERRUPT_CORE               4 /* Must be kept off I/O cores. Best kept off core 0 with the tick ISR. */
 #endif /* appconfI2S_INTERRUPT_CORE */
 
-#ifndef appconfSPI_IO_CORE
-#define appconfSPI_IO_CORE                      1 /* Must be kept off core 0 with the RTOS tick ISR */
-#endif /* appconfSPI_IO_CORE */
-
-#ifndef appconfI2C_IO_CORE
-#define appconfI2C_IO_CORE                      3 /* Must be kept off core 0 with the RTOS tick ISR */
-#endif /* appconfI2C_IO_CORE */
-
-#ifndef appconfI2C_INTERRUPT_CORE
-#define appconfI2C_INTERRUPT_CORE               0 /* Must be kept off I/O cores. */
-#endif /* appconfI2C_INTERRUPT_CORE */
-
-#ifndef appconfSPI_INTERRUPT_CORE
-#define appconfSPI_INTERRUPT_CORE               2 /* Must be kept off I/O cores. */
-#endif /* appconfSPI_INTERRUPT_CORE */
 
 /*****************************************/
-/*  I/O and interrupt cores for Tile 1   */
+/*  I/O Task Priorities                  */
 /*****************************************/
+#ifndef appconfQSPI_FLASH_TASK_PRIORITY
+#define appconfQSPI_FLASH_TASK_PRIORITY		    ( configMAX_PRIORITIES - 1 )
+#endif /* appconfQSPI_FLASH_TASK_PRIORITY */
+
+#ifndef appconfI2C_TASK_PRIORITY
+#define appconfI2C_TASK_PRIORITY                (configMAX_PRIORITIES/2)
+#endif /* appconfI2C_TASK_PRIORITY */
+
+#ifndef appconfSPI_TASK_PRIORITY
+#define appconfSPI_TASK_PRIORITY                (configMAX_PRIORITIES/2)
+#endif /* appconfSPI_TASK_PRIORITY */
+
+#ifndef appconfDEVICE_CONTROL_I2C_PRIORITY
+#define appconfDEVICE_CONTROL_I2C_PRIORITY      (configMAX_PRIORITIES-2)
+#endif // appconfDEVICE_CONTROL_I2C_PRIORITY
+
+
+/*****************************************/
+/*  CONFIGURATION   */
+/*****************************************/
+
 #ifndef appconfPDM_CLOCK_FREQUENCY
 #define appconfPDM_CLOCK_FREQUENCY          MIC_ARRAY_CONFIG_MCLK_FREQ
 #endif /* appconfPDM_CLOCK_FREQUENCY */
@@ -117,10 +160,6 @@
 #define appconf_CONTROL_I2C_DEVICE_ADDR 0x42
 #endif /* appconf_CONTROL_I2C_DEVICE_ADDR*/
 
-#ifndef appconfSPI_OUTPUT_ENABLED
-#define appconfSPI_OUTPUT_ENABLED  0
-#endif /* appconfSPI_OUTPUT_ENABLED */
-
 #ifndef appconfI2S_MODE_MASTER
 #define appconfI2S_MODE_MASTER     0
 #endif /* appconfI2S_MODE_MASTER */
@@ -140,20 +179,6 @@
 #define appconfI2S_TDM_ENABLED     0
 #endif
 
-/*****************************************/
-/*  I/O Task Priorities                  */
-/*****************************************/
-#ifndef appconfQSPI_FLASH_TASK_PRIORITY
-#define appconfQSPI_FLASH_TASK_PRIORITY		    ( configMAX_PRIORITIES - 1 )
-#endif /* appconfQSPI_FLASH_TASK_PRIORITY */
-
-#ifndef appconfI2C_TASK_PRIORITY
-#define appconfI2C_TASK_PRIORITY                (configMAX_PRIORITIES/2)
-#endif /* appconfI2C_TASK_PRIORITY */
-
-#ifndef appconfSPI_TASK_PRIORITY
-#define appconfSPI_TASK_PRIORITY                (configMAX_PRIORITIES/2)
-#endif /* appconfSPI_TASK_PRIORITY */
 
 /*****************************************/
 /*  DFU Settings                         */

--- a/satellite-xmos-firmware/bsp_config/XCORE-AI-EXPLORER/platform/platform_start.c
+++ b/satellite-xmos-firmware/bsp_config/XCORE-AI-EXPLORER/platform/platform_start.c
@@ -21,8 +21,6 @@
 #include "device_control_i2c.h"
 #endif
 
-extern void i2s_rate_conversion_enable(void);
-
 static void gpio_start(void)
 {
     rtos_gpio_rpc_config(gpio_ctx_t0, appconfGPIO_T0_RPC_PORT, appconfGPIO_RPC_PRIORITY);
@@ -127,10 +125,6 @@ static void i2s_start(void)
     rtos_i2s_rpc_config(i2s_ctx, appconfI2S_RPC_PORT, appconfI2S_RPC_PRIORITY);
 
 #if ON_TILE(I2S_TILE_NO)
-    if (appconfI2S_AUDIO_SAMPLE_RATE == 3*appconfAUDIO_PIPELINE_SAMPLE_RATE) {
-        i2s_rate_conversion_enable();
-    }
-
     rtos_i2s_start(
             i2s_ctx,
             rtos_i2s_mclk_bclk_ratio(appconfAUDIO_CLOCK_FREQUENCY, appconfI2S_AUDIO_SAMPLE_RATE),

--- a/satellite-xmos-firmware/src/app_conf_check.h
+++ b/satellite-xmos-firmware/src/app_conf_check.h
@@ -16,12 +16,13 @@
 #error Cannot use wakeword engine in USB configurations
 #endif
 
-#if appconfI2S_TDM_ENABLED && appconfI2S_AUDIO_SAMPLE_RATE != 3*appconfAUDIO_PIPELINE_SAMPLE_RATE
-#error appconfI2S_AUDIO_SAMPLE_RATE must be 48000 to use I2S TDM
-#endif
-
 #if appconfI2S_TDM_ENABLED
 #error TDM mode not longer supported in this firmware version
 #endif
+
+#if (appconfI2S_MODE == appconfI2S_MODE_SLAVE)
+#error I2S_MODE_SLAVE not longer supported in this firmware version
+#endif
+
 
 #endif /* APP_CONF_CHECK_H_ */


### PR DESCRIPTION
- sorting core assignments by tile
- remove code of I2S_SLAVE which is not supported
- remove code of I2S_TDM which is not supported
- remove code of I2S re-sampling callbacks. Re-sampling is done in input/output functions now.