### PR TITLE
Add fph::rtos_ws2812 module

### DIFF
--- a/modules/fph/CMakeLists.txt
+++ b/modules/fph/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(i2s_sync)
 add_subdirectory(rtos_mic_array)
+add_subdirectory(rtos_ws2812)

--- a/modules/fph/rtos_ws2812/CMakeLists.txt
+++ b/modules/fph/rtos_ws2812/CMakeLists.txt
@@ -1,0 +1,20 @@
+
+if((${CMAKE_SYSTEM_NAME} STREQUAL XCORE_XS3A) OR (${CMAKE_SYSTEM_NAME} STREQUAL XCORE_XS2A))
+    ## Create library target
+    add_library(rtos_ws2812 INTERFACE)
+    target_sources(rtos_ws2812
+        INTERFACE
+            src/rtos_ws2812.c
+    )
+    target_include_directories(rtos_ws2812
+        INTERFACE
+            api
+    )
+    target_link_libraries(rtos_ws2812
+        INTERFACE
+            rtos::osal
+    )
+
+    ## Create an alias
+    add_library(fph::rtos_ws2812 ALIAS rtos_ws2812)
+endif()

--- a/modules/fph/rtos_ws2812/api/rtos_ws2812.h
+++ b/modules/fph/rtos_ws2812/api/rtos_ws2812.h
@@ -1,0 +1,66 @@
+#ifndef RTOS_ws2812_H_
+#define RTOS_ws2812_H_
+
+#include "rtos_osal.h"
+#include "rtos_driver_rpc.h"
+
+
+typedef struct {
+    port_t ws2812_port;
+    uint32_t hl_value;
+    rtos_osal_mutex_t lock;
+    uint8_t num_leds;
+
+    rtos_driver_rpc_t *rpc_config;
+    
+} rtos_ws2812_t;
+
+
+
+/**
+ * Writes data to an initialized and started ws2812 driver instance.
+ * An xcore logical core is not reserved. The transmission
+ * is a function call and the function blocks until the bit of the last
+ * byte to be transmittted has completed. Interrupts are masked during this time
+ * to avoid stretching of the waveform. Consequently, the function consumes cycles from
+ * the caller thread.
+ *
+ * \param ctx             A pointer to the ws2812 driver instance to use.
+ * \param buf             The buffer containing data to write.
+ */
+void rtos_ws2812_write( rtos_ws2812_t *ctx, const uint8_t buf[] );
+
+
+
+/**
+ * Starts an RTOS ws2812 driver instance. This must only be called by the tile that
+ * owns the driver instance. It may be called either before or after starting
+ * the RTOS, but must be called before any of the core ws2812 driver functions are
+ * called with this instance.
+ *
+ * rtos_ws2812_init() must be called on this ws2812 driver instance prior to calling this.
+ *
+ * \param ctx       A pointer to the ws2812 driver instance to start.
+ */
+void rtos_ws2812_start(rtos_ws2812_t *ctx);
+
+
+
+/**
+ * Initialises an RTOS ws2812 driver instance.
+ * This must only be called by the tile that owns the driver instance. It may be
+ * called either before or after starting the RTOS, but must be called before calling
+ * rtos_ws2812_start() or any of the core ws2812 driver functions with this instance.
+ *
+ * \param ctx        A pointer to the ws2812 driver instance to initialise.
+ * \param port       The port containing the ws2812 pin
+ * \param pin        The ws2812 pin number.
+ * \param num_leds   The number of leds on the ws2812 bus.
+ */
+void rtos_ws2812_init(
+        rtos_ws2812_t *ctx,
+        const port_t port,
+        const uint8_t pin,
+        const uint8_t num_leds );
+
+#endif

--- a/modules/fph/rtos_ws2812/src/rtos_ws2812.c
+++ b/modules/fph/rtos_ws2812/src/rtos_ws2812.c
@@ -1,0 +1,87 @@
+
+#include <xcore/port.h>
+#include <xcore/channel.h>
+
+#include "rtos_ws2812.h"
+
+#define T1H  900    // Width of a 1 bit in ns
+#define T1L  500    // Width of a 1 bit in ns
+
+#define T0H  400    // Width of a 0 bit in ns
+#define T0L  900    // Width of a 0 bit in ns
+
+#define RES 250000    // Width of the low gap between bits to cause a frame to latch
+
+#define NS_PER_SEC (1000000000L)
+
+#define NS_PER_CYCLE ( NS_PER_SEC / XS1_TIMER_HZ )
+#define NS_TO_CYCLES(n) ( (n) / NS_PER_CYCLE )
+
+
+
+static void ws2812_local_write(
+        rtos_ws2812_t *ctx,
+        const uint8_t buff[],
+        size_t n)
+{
+    port_t p = ctx->ws2812_port;
+    const uint32_t hl_value = ctx->hl_value;
+    port_enable(p);
+    port_out(p, 0);
+    int t;
+    t = port_get_trigger_time(p);
+
+    //In case two threads try to access at the same time
+    rtos_osal_mutex_get(&ctx->lock, RTOS_OSAL_WAIT_FOREVER);
+
+    //To prevent interruption of Tx frame
+    rtos_interrupt_mask_all();
+    
+    for(int i = 0; i < n; i++){
+        uint8_t b = buff[i];
+        for (int j = 0; j < 8; j++) {
+            if ( b & (1 << 7) ){
+                port_out_at_time(p, t, hl_value);
+                t +=  NS_TO_CYCLES( T1H );
+                port_out_at_time(p, t, 0);
+                t +=  NS_TO_CYCLES( T1L );    
+            } else {
+                port_out_at_time(p, t, hl_value);
+                t +=  NS_TO_CYCLES( T0H );
+                port_out_at_time(p, t, 0);
+                t +=  NS_TO_CYCLES( T0L );    
+            }
+            b <<= 1;
+        }
+    }
+    t += NS_TO_CYCLES(RES);
+    port_out_at_time(p, t, 0);
+    rtos_interrupt_unmask_all();
+    rtos_osal_mutex_put(&ctx->lock);
+}
+
+
+void rtos_ws2812_write( rtos_ws2812_t *ctx, const uint8_t buf[] ){
+    ws2812_local_write( ctx, buf, ctx->num_leds * 3);
+}
+
+void rtos_ws2812_start( rtos_ws2812_t *ctx ){
+    rtos_osal_mutex_create(&ctx->lock, "ws2812_lock", RTOS_OSAL_RECURSIVE);
+
+    //if (ctx->rpc_config != NULL && ctx->rpc_config->rpc_host_start != NULL) {
+    //    ctx->rpc_config->rpc_host_start(ctx->rpc_config);
+    //}
+}
+
+
+void rtos_ws2812_init(
+        rtos_ws2812_t *ctx,
+        port_t ws2812port,
+        const uint8_t pin,
+        const uint8_t num_leds
+)
+{
+    ctx->ws2812_port = ws2812port;
+    ctx->hl_value = (1 << pin);
+    ctx->num_leds = num_leds;
+}

--- a/satellite-xmos-firmware/bsp_config/XCORE-AI-EXPLORER/XCORE-AI-EXPLORER.cmake
+++ b/satellite-xmos-firmware/bsp_config/XCORE-AI-EXPLORER/XCORE-AI-EXPLORER.cmake
@@ -22,6 +22,7 @@ target_link_libraries(sln_voice_app_ffva_board_support_xcore_ai_explorer
         #rtos::drivers::mic_array
         fph::rtos_mic_array
         fph::i2s_sync
+        fph::rtos_ws2812
         rtos::drivers::usb
         rtos::drivers::dfu_image
         sln_voice::app::ffva::dac::aic3204

--- a/satellite-xmos-firmware/bsp_config/XCORE-AI-EXPLORER/XCORE-AI-EXPLORER.xn
+++ b/satellite-xmos-firmware/bsp_config/XCORE-AI-EXPLORER/XCORE-AI-EXPLORER.xn
@@ -83,6 +83,8 @@
 
             <Port Location="XS1_PORT_1M" Name="PORT_I2S_ESP_DATA_OUT"/>
             <Port Location="XS1_PORT_1O" Name="PORT_I2S_ESP_DATA_IN"/>
+
+            <Port Location="XS1_PORT_4C" Name="PORT_LED_RING"/>
           
           </Tile>
         </Node>

--- a/satellite-xmos-firmware/bsp_config/XCORE-AI-EXPLORER/platform/driver_instances.c
+++ b/satellite-xmos-firmware/bsp_config/XCORE-AI-EXPLORER/platform/driver_instances.c
@@ -35,3 +35,6 @@ rtos_spi_slave_t *spi_slave_ctx = &spi_slave_ctx_s;
 
 static rtos_dfu_image_t dfu_image_ctx_s;
 rtos_dfu_image_t *dfu_image_ctx = &dfu_image_ctx_s;
+
+static rtos_ws2812_t ws2812_ctx_s;
+rtos_ws2812_t *ws2812_ctx = &ws2812_ctx_s;

--- a/satellite-xmos-firmware/bsp_config/XCORE-AI-EXPLORER/platform/driver_instances.h
+++ b/satellite-xmos-firmware/bsp_config/XCORE-AI-EXPLORER/platform/driver_instances.h
@@ -13,15 +13,19 @@
 #include "rtos_qspi_flash.h"
 #include "rtos_dfu_image.h"
 #include "rtos_spi_slave.h"
+#include "rtos_ws2812.h"
 
 /* Tile specifiers */
 #define FLASH_TILE_NO      0
 #define I2C_TILE_NO        0
 #define I2C_CTRL_TILE_NO   I2C_TILE_NO
+
 #define SPI_OUTPUT_TILE_NO 1
 #define MICARRAY_TILE_NO   1
 #define I2S_TILE_NO        1
 #define SPEAKER_PIPELINE_TILE_NO I2S_TILE_NO 
+#define WS2812_TILE_NO     1
+
 
 /** TILE 0 Clock Blocks */
 #define FLASH_CLKBLK  XS1_CLKBLK_1
@@ -44,6 +48,10 @@
 #define PORT_SPI_MOSI       WIFI_MOSI
 #define PORT_SPI_MISO       WIFI_MISO
 
+/*LED RING*/
+#define LED_RING_NUM_LEDS   12
+#define LED_RING_PORT_PIN    2
+
 extern rtos_intertile_t *intertile_ctx;
 extern rtos_intertile_t *intertile_usb_audio_ctx;
 extern rtos_qspi_flash_t *qspi_flash_ctx;
@@ -55,5 +63,6 @@ extern rtos_i2c_slave_t *i2c_slave_ctx;
 extern rtos_spi_slave_t *spi_slave_ctx;
 extern rtos_i2s_t *i2s_ctx;
 extern rtos_dfu_image_t *dfu_image_ctx;
+extern rtos_ws2812_t *ws2812_ctx;
 
 #endif /* DRIVER_INSTANCES_H_ */

--- a/satellite-xmos-firmware/bsp_config/XCORE-AI-EXPLORER/platform/platform_init.c
+++ b/satellite-xmos-firmware/bsp_config/XCORE-AI-EXPLORER/platform/platform_init.c
@@ -210,6 +210,14 @@ static void usb_init(void)
 #endif
 }
 
+static void ws2812_init(void)
+{
+#if ON_TILE(WS2812_TILE_NO)
+   rtos_ws2812_init(ws2812_ctx, PORT_LED_RING, LED_RING_PORT_PIN, LED_RING_NUM_LEDS); 
+#endif    
+}
+
+
 void platform_init(chanend_t other_tile_c)
 {
     rtos_intertile_init(intertile_ctx, other_tile_c);
@@ -223,4 +231,5 @@ void platform_init(chanend_t other_tile_c)
     mics_init();
     i2s_init();
     usb_init();
+    ws2812_init();
 }

--- a/satellite-xmos-firmware/bsp_config/XCORE-AI-EXPLORER/platform/platform_start.c
+++ b/satellite-xmos-firmware/bsp_config/XCORE-AI-EXPLORER/platform/platform_start.c
@@ -143,6 +143,14 @@ static void usb_start(void)
 #endif
 }
 
+static void ws2812_start(void)
+{
+#if ON_TILE(WS2812_TILE_NO)
+    rtos_ws2812_start(ws2812_ctx);
+#endif    
+}
+
+
 void platform_start(void)
 {
     rtos_intertile_start(intertile_ctx);
@@ -157,4 +165,5 @@ void platform_start(void)
     mics_start();
     i2s_start();
     usb_start();
+    ws2812_start();
 }

--- a/satellite-xmos-firmware/src/main.c
+++ b/satellite-xmos-firmware/src/main.c
@@ -314,6 +314,12 @@ void startup_task(void *arg)
     );
 #endif
 
+#if ON_TILE(WS2812_TILE_NO)
+    static uint8_t neo_pixel_buffer[12 * 3];
+    memset( neo_pixel_buffer, 128, 12 * 3);
+    rtos_ws2812_write( ws2812_ctx, neo_pixel_buffer);
+#endif
+
 #if appconfINTENT_ENABLED && ON_TILE(0)
     led_task_create(appconfLED_TASK_PRIORITY, NULL);
 #endif


### PR DESCRIPTION
- introduce fph::rtos_ws2812 module (rpc not supported yet)
- sets leds to white at startup as an usage example