### PR TITLE
Disable SPI-DEVICE-CNTRL

### DIFF
--- a/satellite-xmos-firmware/satellite1.cmake
+++ b/satellite-xmos-firmware/satellite1.cmake
@@ -10,6 +10,7 @@ foreach(FFVA_AP ${FFVA_PIPELINES_INT})
         appconfAEC_REF_DEFAULT=appconfAEC_REF_I2S
         appconfI2S_MODE=appconfI2S_MODE_MASTER
         appconfI2S_AUDIO_SAMPLE_RATE=48000
+        appconfDEVICE_CTRL_SPI=0
     )
 
     if(${FFVA_AP} STREQUAL bypass )

--- a/satellite-xmos-firmware/src/main.c
+++ b/satellite-xmos-firmware/src/main.c
@@ -297,6 +297,13 @@ void startup_task(void *arg)
     rtos_printf("Startup task running from tile %d on core %d\n", THIS_XCORE_TILE, portGET_CORE_ID());
     platform_start();
 
+#if ON_TILE(WS2812_TILE_NO)
+    static uint8_t neo_pixel_buffer[LED_RING_NUM_LEDS * 3];
+    memset( neo_pixel_buffer, 20, LED_RING_NUM_LEDS * 3);
+    rtos_ws2812_write( ws2812_ctx, neo_pixel_buffer);
+#endif
+
+
 #if appconfDEVICE_CTRL_SPI
     device_control_t *device_control_ctx[1] = {device_control_spi_ctx}; 
 
@@ -326,10 +333,6 @@ void startup_task(void *arg)
 #endif
 
 #if ON_TILE(WS2812_TILE_NO)
-    static uint8_t neo_pixel_buffer[LED_RING_NUM_LEDS * 3];
-    memset( neo_pixel_buffer, 20, LED_RING_NUM_LEDS * 3);
-    rtos_ws2812_write( ws2812_ctx, neo_pixel_buffer);
-    
     servicer_t servicer_led_ring;
     led_ring_servicer_init(&servicer_led_ring);
     


### PR DESCRIPTION
* set appconfDEVICE_CTRL_SPI=0 for Satellite1 builds
* move initial LED setup outside of appconfDEVICE_CTRL_SPI check