### PR TITLE
Build fixed delay variant only

### DIFF
--- a/tools/ci/firmwares.txt
+++ b/tools/ci/firmwares.txt
@@ -1,3 +1,1 @@
-satellite1_adec  satellite1_firmware_adec No  SATELLITE1   xmos_cmake_toolchain/xs3a.cmake
 satellite1_fixed  satellite1_firmware_fixed_delay No  SATELLITE1   xmos_cmake_toolchain/xs3a.cmake
-satellite1_bypass  satellite1_firmware_bypass No  SATELLITE1   xmos_cmake_toolchain/xs3a.cmake


### PR DESCRIPTION
Right now we are only using the fixed delay variant. There is no need for building three different variants, it just takes compute time.