### PR TITLE
GHA: updated venv creation for xmos-ai-tools dependency

### DIFF
--- a/tools/ci/helper_functions.sh
+++ b/tools/ci/helper_functions.sh
@@ -75,7 +75,8 @@ function setup_python_env() {
         # Activate the virtual environment
         echo "Activating virtual environment in ${venv_dir}..."
         source "${venv_dir}/bin/activate"
-        pip install --no-cache-dir xmos_ai_tools
+        python -m pip install --upgrade pip
+        pip install --no-cache-dir -r "${req_file}"
         echo "Python environment setup complete."
     else 
         # Activate the virtual environment


### PR DESCRIPTION
Build the beta release failed due to hash mismatch of the xmos-ai-tools python library.
This PR should fix this.