### PR TITLE
reset the watchdog on tile0 only

### DIFF
--- a/satellite-xmos-firmware/src/main.c
+++ b/satellite-xmos-firmware/src/main.c
@@ -289,7 +289,9 @@ static void mem_analysis(void)
 	for (;;) {
 		rtos_printf("Tile[%d]:\n\tMinimum heap free: %d\n\tCurrent heap free: %d\n", THIS_XCORE_TILE, xPortGetMinimumEverFreeHeapSize(), xPortGetFreeHeapSize());
         cdc_printf("Tile[%d]:\n\tMinimum heap free: %d\n\tCurrent heap free: %d\n", THIS_XCORE_TILE, xPortGetMinimumEverFreeHeapSize(), xPortGetFreeHeapSize());
-		reset_watchdog();
+#if ON_TILE(0)        
+        reset_watchdog();
+#endif        
         vTaskDelay(pdMS_TO_TICKS(5000));
 	}
 }


### PR DESCRIPTION
Reset the watchdog only on tile 0, this prevents resetting the wd if only tile0 freezes...