### PR TITLE
allow CI version input changes

### DIFF
--- a/satellite-xmos-firmware/firmware.cmake
+++ b/satellite-xmos-firmware/firmware.cmake
@@ -16,7 +16,7 @@ add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/audio_pipelines)
 
 set(VERSIONING_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/versioning.py)
 option(USE_DEV_TRACKING "Enable dev-build tracking" OFF)
-option(ALLOW_DIRTY_VERSIONING "Allow versioning.py to run from a dirty workspace" OFF)
+option(ALLOW_DIRTY_VERSIONING "Allow versioning.py to run from a dirty workspace for controlled CI inputs or local throwaway builds" OFF)
 
 #**********************
 # Flags

--- a/satellite-xmos-firmware/versioning.py
+++ b/satellite-xmos-firmware/versioning.py
@@ -357,7 +357,8 @@ def assert_clean_workspace(args: argparse.Namespace) -> None:
         Refusing to build from a dirty workspace: {git_info}
 
         Commit or stash local changes before building reproducible firmware artifacts.
-        Use --allow-dirty only for local throwaway builds.
+        Use --allow-dirty only for controlled CI builds that inject firmware_version.txt
+        or for local throwaway builds.
         """)
     )
     sys.exit(1)

--- a/tools/ci/build_firmware.sh
+++ b/tools/ci/build_firmware.sh
@@ -66,7 +66,7 @@ for ((i = 0; i < ${#examples[@]}; i += 1)); do
 
     (cd ${path}; rm -rf build_${board})
     (cd ${path}; mkdir -p build_${board})
-    (cd ${path}/build_${board}; log_errors cmake ../ -G "$CI_CMAKE_GENERATOR" -DCMAKE_TOOLCHAIN_FILE=${toolchain_file} -DBOARD=${board} -DENABLE_ALL_FFVA_PIPELINES=1; log_errors $CI_BUILD_TOOL ${app_target} $CI_BUILD_TOOL_ARGS)
+    (cd ${path}/build_${board}; log_errors cmake ../ -G "$CI_CMAKE_GENERATOR" -DCMAKE_TOOLCHAIN_FILE=${toolchain_file} -DBOARD=${board} -DENABLE_ALL_FFVA_PIPELINES=1 -DALLOW_DIRTY_VERSIONING=ON; log_errors $CI_BUILD_TOOL ${app_target} $CI_BUILD_TOOL_ARGS)
     (cd ${path}/build_${board}; cp ${app_target}.xe ${DIST_DIR})
     
     if [ "$run_data_partition_target" = "Yes" ]; then


### PR DESCRIPTION
FIX: GHA failed building the firmware as it writes the version.txt file which made the workspace dirty.