### PR TITLE
ci: update checkout action to v5

### DIFF
--- a/.github/workflows/apps.yml
+++ b/.github/workflows/apps.yml
@@ -42,7 +42,7 @@ jobs:
       requires_data_partition: ${{ steps.check_manifest.outputs.requires_data_partition }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check for data partition builds
         id: check_manifest
@@ -60,7 +60,7 @@ jobs:
     if: ${{ needs.manifest_preflight.outputs.requires_data_partition == 'true' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -87,7 +87,7 @@ jobs:
     if: ${{ always() && needs.manifest_preflight.result == 'success' && (needs.build_host_apps.result == 'success' || needs.build_host_apps.result == 'skipped') }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       


### PR DESCRIPTION
Updates all GitHub Actions checkout steps from actions/checkout@v4 to @v5, eliminating the Node.js 20 deprecation warning on GitHub-hosted runners.