### PR TITLE
ci: package XMOS firmware as Debian payload

### DIFF
--- a/.github/workflows/apps.yml
+++ b/.github/workflows/apps.yml
@@ -14,6 +14,12 @@ name: Build Applications
 on:
   # Allow manually triggering of the workflow.
   workflow_dispatch:
+    inputs:
+      package_revision:
+        description: 'Debian packaging revision for the XMOS firmware package.'
+        type: string
+        required: false
+        default: "1"
 
   # Allow workflow to be called from another.
   workflow_call:
@@ -28,6 +34,11 @@ on:
         type: string
         required: false
         default: "dev"
+      package_revision:
+        description: 'Debian packaging revision for the XMOS firmware package.'
+        type: string
+        required: false
+        default: "1"
 
 env:
   XCORE_BUILDER: "ghcr.io/xmos/xcore_builder:v3.1"
@@ -113,6 +124,12 @@ jobs:
       - name: Save metadata
         run: |
           bash tools/ci/log_metadata.sh ./dist/build_metadata.json
+
+      - name: Package Satellite1 XMOS firmware for Debian
+        env:
+          PACKAGE_REVISION: ${{ inputs.package_revision }}
+        run: |
+          bash tools/ci/package_firmware_deb.sh
 
       - name: Determine artifact name
         run: |

--- a/.github/workflows/apps.yml
+++ b/.github/workflows/apps.yml
@@ -44,6 +44,7 @@ env:
   XCORE_BUILDER: "ghcr.io/xmos/xcore_builder:v3.1"
   HOST_APPS_ARTIFACT_NAME: "host_apps"
   FIRMWARE_ARTIFACT_NAME: "satellite1_firmware"
+  DEBIAN_PACKAGE_ARTIFACT_NAME: "satellite1_firmware_deb"
 
 jobs:
   manifest_preflight:
@@ -143,3 +144,10 @@ jobs:
           name: ${{ env.FIRMWARE_ARTIFACT_NAME }}
           path: |
             ./dist/*.*
+            !./dist/*.deb
+
+      - name: Save Debian package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.DEBIAN_PACKAGE_ARTIFACT_NAME }}
+          path: ./dist/*.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,10 @@ on:
       tag:
         description: 'Tag for the release.'
         required: true
+      package_revision:
+        description: 'Debian packaging revision for the XMOS firmware package.'
+        required: false
+        default: "1"
 
 env:
   TMP_SOURCES_DIR: ${{ github.workspace }}/tmp/src
@@ -96,6 +100,7 @@ jobs:
     with:
       firmware_artifact_name: ${{ needs.create_release_tag.outputs.firmware_artifact_name }}
       firmware_version_string: ${{ needs.create_release_tag.outputs.new_tag }}
+      package_revision: ${{ github.event.inputs.package_revision || '1' }}
 
   create_release:
     name: Release Firmware

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ env:
   TMP_SOURCES_DIR: ${{ github.workspace }}/tmp/src
   RELEASE_SOURCES_DIR: ${{ github.workspace }}/release/src
   FIRMWARE_ARTIFACT_NAME: "satellite_firmware_apps"
+  DEBIAN_PACKAGE_ARTIFACT_NAME: "satellite1_firmware_deb"
 permissions:
   contents: write
 
@@ -116,6 +117,12 @@ jobs:
           name: ${{ env.FIRMWARE_ARTIFACT_NAME }}
           path: ${{ env.RELEASE_SOURCES_DIR }}
 
+      - name: Get Debian package
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.DEBIAN_PACKAGE_ARTIFACT_NAME }}
+          path: ${{ github.workspace }}/release/debian
+
       - name: Zip Release Binaries
         run: |
           cd ${{ env.RELEASE_SOURCES_DIR }}
@@ -126,7 +133,9 @@ jobs:
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
-          files: ${{ env.RELEASE_SOURCES_DIR }}/${{ env.FIRMWARE_ARTIFACT_NAME }}.zip
+          files: |
+            ${{ env.RELEASE_SOURCES_DIR }}/${{ env.FIRMWARE_ARTIFACT_NAME }}.zip
+            ${{ github.workspace }}/release/debian/*.deb
           generate_release_notes: true
           append_body: true
           tag_name: ${{ needs.create_release_tag.outputs.new_tag }}

--- a/debian/control.in
+++ b/debian/control.in
@@ -1,0 +1,8 @@
+Package: satellite1-xmos-firmware
+Version: @PACKAGE_VERSION@
+Section: firmware
+Priority: optional
+Architecture: all
+Maintainer: Future Proof Homes <engineering@futureproofhomes.com>
+Description: Satellite1 XMOS firmware images
+ Factory and update images for the Satellite1 XMOS processor.

--- a/debian/control.in
+++ b/debian/control.in
@@ -3,6 +3,6 @@ Version: @PACKAGE_VERSION@
 Section: firmware
 Priority: optional
 Architecture: all
-Maintainer: Future Proof Homes <engineering@futureproofhomes.com>
+Maintainer: Mischa Siekmann <mischa.siekmann@futureproofhomes.net>
 Description: Satellite1 XMOS firmware images
  Factory and update images for the Satellite1 XMOS processor.

--- a/tests/test_package_firmware_deb.py
+++ b/tests/test_package_firmware_deb.py
@@ -1,0 +1,103 @@
+import hashlib
+import json
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+from tests.conftest import PROJ_ROOT
+
+
+SCRIPT = PROJ_ROOT / "tools" / "ci" / "package_firmware_deb.sh"
+CONTROL_TEMPLATE = PROJ_ROOT / "debian" / "control.in"
+DPKG_DEB = shutil.which("dpkg-deb")
+
+
+@pytest.mark.skipif(DPKG_DEB is None, reason="dpkg-deb is required for Debian package tests")
+def test_packages_discovered_images_with_manifest(tmp_path: Path):
+    dist = tmp_path / "dist"
+    output = tmp_path / "output"
+    dist.mkdir()
+    factory = dist / "custom-board.factory.bin"
+    update = dist / "custom-board.upgrade.bin"
+    factory.write_bytes(b"factory bytes\x00")
+    update.write_bytes(b"update bytes\x01")
+    version_file = tmp_path / "firmware_version.txt"
+    version_file.write_text("v1.2.3-alpha.4\n")
+
+    result = subprocess.run(
+        [
+            "bash", str(SCRIPT), "--dist-dir", str(dist), "--output-dir", str(output),
+            "--version-file", str(version_file), "--control-template", str(CONTROL_TEMPLATE),
+            "--package-revision", "9",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    package = output / "satellite1-xmos-firmware_1.2.3-alpha.4-9_all.deb"
+    assert package.is_file(), result.stdout
+    assert subprocess.run([DPKG_DEB, "-f", package, "Package"], capture_output=True, text=True, check=True).stdout.strip() == "satellite1-xmos-firmware"
+    assert subprocess.run([DPKG_DEB, "-f", package, "Version"], capture_output=True, text=True, check=True).stdout.strip() == "1.2.3-alpha.4-9"
+    assert subprocess.run([DPKG_DEB, "-f", package, "Architecture"], capture_output=True, text=True, check=True).stdout.strip() == "all"
+    assert subprocess.run([DPKG_DEB, "-f", package, "Depends"], capture_output=True, text=True, check=True).stdout.strip() == ""
+
+    extracted = tmp_path / "extracted"
+    subprocess.run([DPKG_DEB, "-x", package, extracted], check=True)
+    payload = extracted / "usr/lib/firmware/satellite1/xmos"
+    manifest = json.loads((payload / "manifest.json").read_text())
+    assert list(manifest) == [
+        "schema_version", "firmware_version", "factory_image",
+        "factory_image_sha256", "update_image", "update_image_sha256",
+    ]
+    assert manifest["schema_version"] == 1
+    assert manifest["firmware_version"] == "v1.2.3-alpha.4"
+    assert manifest["factory_image"] == factory.name
+    assert manifest["update_image"] == update.name
+    assert manifest["factory_image_sha256"] == hashlib.sha256(factory.read_bytes()).hexdigest()
+    assert manifest["update_image_sha256"] == hashlib.sha256(update.read_bytes()).hexdigest()
+
+
+def test_rejects_ambiguous_factory_images(tmp_path: Path):
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "one.factory.bin").write_bytes(b"one")
+    (dist / "two.factory.bin").write_bytes(b"two")
+    (dist / "one.upgrade.bin").write_bytes(b"update")
+    version_file = tmp_path / "firmware_version.txt"
+    version_file.write_text("v1.2.3\n")
+
+    result = subprocess.run(
+        [
+            "bash", str(SCRIPT), "--dist-dir", str(dist), "--output-dir", str(tmp_path / "output"),
+            "--version-file", str(version_file), "--control-template", str(CONTROL_TEMPLATE),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "expected exactly one *.factory.bin" in result.stderr
+
+
+def test_rejects_non_release_version(tmp_path: Path):
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "board.factory.bin").write_bytes(b"factory")
+    (dist / "board.upgrade.bin").write_bytes(b"update")
+    version_file = tmp_path / "firmware_version.txt"
+    version_file.write_text("dev\n")
+
+    result = subprocess.run(
+        [
+            "bash", str(SCRIPT), "--dist-dir", str(dist), "--output-dir", str(tmp_path / "output"),
+            "--version-file", str(version_file), "--control-template", str(CONTROL_TEMPLATE),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "firmware version must be a release version" in result.stderr

--- a/tools/ci/package_firmware_deb.sh
+++ b/tools/ci/package_firmware_deb.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Build a payload-only Debian package from the firmware images already in dist/.
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+dist_dir="$repo_root/dist"
+output_dir="$dist_dir"
+version_file="$repo_root/firmware_version.txt"
+control_template="$repo_root/debian/control.in"
+package_revision="${PACKAGE_REVISION:-1}"
+
+usage() {
+    cat <<'EOF'
+Usage: package_firmware_deb.sh [options]
+
+Build satellite1-xmos-firmware from one *.factory.bin and one *.upgrade.bin in
+the distribution directory. PACKAGE_REVISION defaults to 1.
+
+Options:
+  --dist-dir DIR          Directory containing firmware images (default: dist/)
+  --output-dir DIR        Directory for the resulting .deb (default: dist/)
+  --version-file FILE     Firmware version source (default: firmware_version.txt)
+  --control-template FILE Debian control template (default: debian/control.in)
+  --package-revision REV  Debian packaging revision (default: PACKAGE_REVISION or 1)
+EOF
+}
+
+while (($#)); do
+    case "$1" in
+        --dist-dir) dist_dir="$2"; shift 2 ;;
+        --output-dir) output_dir="$2"; shift 2 ;;
+        --version-file) version_file="$2"; shift 2 ;;
+        --control-template) control_template="$2"; shift 2 ;;
+        --package-revision) package_revision="$2"; shift 2 ;;
+        --help|-h) usage; exit 0 ;;
+        *) echo "ERROR: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+for required in "$dist_dir" "$version_file" "$control_template"; do
+    if [[ ! -e "$required" ]]; then
+        echo "ERROR: required path does not exist: $required" >&2
+        exit 1
+    fi
+done
+
+firmware_version=$(python3 - "$version_file" <<'PY'
+from pathlib import Path
+import sys
+
+lines = Path(sys.argv[1]).read_text().splitlines()
+if len(lines) != 1 or not lines[0]:
+    raise SystemExit("ERROR: firmware version must contain exactly one non-empty line")
+print(lines[0])
+PY
+)
+debian_upstream_version=${firmware_version#v}
+if [[ ! "$debian_upstream_version" =~ ^[0-9] ]]; then
+    echo "ERROR: firmware version must be a release version beginning with an optional v followed by a digit" >&2
+    exit 1
+fi
+if [[ ! "$package_revision" =~ ^[A-Za-z0-9.+~]+$ ]]; then
+    echo "ERROR: invalid Debian packaging revision: $package_revision" >&2
+    exit 1
+fi
+package_version="${debian_upstream_version}-${package_revision}"
+
+shopt -s nullglob
+factory_images=("$dist_dir"/*.factory.bin)
+update_images=("$dist_dir"/*.upgrade.bin)
+shopt -u nullglob
+if ((${#factory_images[@]} != 1)); then
+    echo "ERROR: expected exactly one *.factory.bin in $dist_dir; found ${#factory_images[@]}" >&2
+    exit 1
+fi
+if ((${#update_images[@]} != 1)); then
+    echo "ERROR: expected exactly one *.upgrade.bin in $dist_dir; found ${#update_images[@]}" >&2
+    exit 1
+fi
+for image in "${factory_images[0]}" "${update_images[0]}"; do
+    if [[ ! -f "$image" ]]; then
+        echo "ERROR: firmware image is not a regular file: $image" >&2
+        exit 1
+    fi
+done
+
+stage_dir=$(mktemp -d "${TMPDIR:-/tmp}/satellite1-xmos-firmware.XXXXXX")
+cleanup() { rm -rf "$stage_dir"; }
+trap cleanup EXIT
+payload_dir="$stage_dir/usr/lib/firmware/satellite1/xmos"
+mkdir -p "$stage_dir/DEBIAN" "$payload_dir" "$output_dir"
+
+factory_name=$(basename "${factory_images[0]}")
+update_name=$(basename "${update_images[0]}")
+cp "${factory_images[0]}" "$payload_dir/$factory_name"
+cp "${update_images[0]}" "$payload_dir/$update_name"
+
+python3 - "$control_template" "$stage_dir/DEBIAN/control" "$package_version" <<'PY'
+from pathlib import Path
+import sys
+
+template = Path(sys.argv[1])
+output = Path(sys.argv[2])
+package_version = sys.argv[3]
+control = template.read_text()
+if control.count("@PACKAGE_VERSION@") != 1:
+    raise SystemExit("control template must contain exactly one @PACKAGE_VERSION@ placeholder")
+Path(output).write_text(control.replace("@PACKAGE_VERSION@", package_version))
+PY
+
+manifest="$payload_dir/manifest.json"
+python3 - "$manifest" "$firmware_version" "$payload_dir/$factory_name" "$payload_dir/$update_name" <<'PY'
+import hashlib
+import json
+from pathlib import Path
+import sys
+
+manifest, firmware_version, factory, update = sys.argv[1:]
+def sha256(path):
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+payload = {
+    "schema_version": 1,
+    "firmware_version": firmware_version,
+    "factory_image": Path(factory).name,
+    "factory_image_sha256": sha256(factory),
+    "update_image": Path(update).name,
+    "update_image_sha256": sha256(update),
+}
+Path(manifest).write_text(json.dumps(payload, indent=2) + "\n")
+PY
+
+package_path="$output_dir/satellite1-xmos-firmware_${package_version}_all.deb"
+dpkg-deb --build --root-owner-group "$stage_dir" "$package_path" >/dev/null
+
+dpkg-deb --info "$package_path" >/dev/null
+[[ $(dpkg-deb --field "$package_path" Package) == "satellite1-xmos-firmware" ]]
+[[ $(dpkg-deb --field "$package_path" Version) == "$package_version" ]]
+[[ $(dpkg-deb --field "$package_path" Architecture) == "all" ]]
+[[ -z $(dpkg-deb --field "$package_path" Depends) ]]
+contents=$(dpkg-deb --contents "$package_path")
+for path in "$factory_name" "$update_name" manifest.json; do
+    [[ "$contents" == *"./usr/lib/firmware/satellite1/xmos/$path"* ]] || {
+        echo "ERROR: package is missing payload path: $path" >&2
+        exit 1
+    }
+done
+
+extract_dir="$stage_dir/extract"
+dpkg-deb --extract "$package_path" "$extract_dir"
+python3 - "$extract_dir/usr/lib/firmware/satellite1/xmos/manifest.json" "$firmware_version" <<'PY'
+import hashlib
+import json
+from pathlib import Path
+import sys
+
+manifest_path = Path(sys.argv[1])
+firmware_version = sys.argv[2]
+manifest = json.loads(manifest_path.read_text())
+expected_keys = [
+    "schema_version", "firmware_version", "factory_image",
+    "factory_image_sha256", "update_image", "update_image_sha256",
+]
+if list(manifest) != expected_keys:
+    raise SystemExit(f"unexpected manifest fields: {list(manifest)}")
+if manifest["schema_version"] != 1 or manifest["firmware_version"] != firmware_version:
+    raise SystemExit("manifest version does not match package inputs")
+for image_key, checksum_key in (("factory_image", "factory_image_sha256"), ("update_image", "update_image_sha256")):
+    image = manifest_path.parent / manifest[image_key]
+    if not image.is_file() or hashlib.sha256(image.read_bytes()).hexdigest() != manifest[checksum_key]:
+        raise SystemExit(f"manifest checksum does not match staged {image_key}")
+PY
+
+printf 'Built %s\n' "$package_path"


### PR DESCRIPTION
Let the CI also create a detain package.
The package installs factory/update images and a checksum-verified manifest under /usr/lib/firmware/satellite1/xmos/, with no SDK dependency or installation-time hardware actions.