### PR TITLE
Fix bypass firmware IC skip macro

### DIFF
--- a/satellite-xmos-firmware/audio_pipelines/reference/fixed_delay/audio_pipeline_t0.c
+++ b/satellite-xmos-firmware/audio_pipelines/reference/fixed_delay/audio_pipeline_t0.c
@@ -74,7 +74,7 @@ static int audio_pipeline_output_i(frame_data_t *frame_data,
 
 static void stage_vnr_and_ic(frame_data_t *frame_data)
 {
-#if appconfAUDIO_PIPELINE_SKIP_IC_AND_VAD
+#if appconfAUDIO_PIPELINE_SKIP_IC_AND_VNR
 #else
     int32_t DWORD_ALIGNED ic_output[appconfAUDIO_PIPELINE_FRAME_ADVANCE];
     ic_filter(&ic_stage_state.state,


### PR DESCRIPTION
## What changed

Correct the bypass pipeline’s IC skip guard in `audio_pipelines/reference/fixed_delay/audio_pipeline_t0.c`.

The bypass configuration defines:

```c
appconfAUDIO_PIPELINE_SKIP_IC_AND_VNR
```

but the fixed-delay pipeline checked the misspelled `appconfAUDIO_PIPELINE_SKIP_IC_AND_VAD`.

As a result, bypass builds unintentionally continued running interference cancellation. This change makes bypass firmware skip IC as intended.

## Validation

- Built the Satellite1 firmware with XMOS XTC Tools 15.3.1.
- The corrected bypass guard compiles successfully.
- No source behavior outside the bypass guard is changed.